### PR TITLE
feat: 홈 화면 조회 API 구현

### DIFF
--- a/src/main/java/swyp_11/ssubom/domain/post/dto/TodayPostResponse.java
+++ b/src/main/java/swyp_11/ssubom/domain/post/dto/TodayPostResponse.java
@@ -1,0 +1,24 @@
+package swyp_11.ssubom.domain.post.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import swyp_11.ssubom.domain.post.entity.PostStatus;
+
+@Getter
+public class TodayPostResponse {
+    private Long postId;
+    private String postStatus;
+
+    @Builder
+    public TodayPostResponse(Long postId, String postStatus) {
+        this.postId = postId;
+        this.postStatus = postStatus;
+    }
+
+    public static TodayPostResponse toDto(Long postId, PostStatus status) {
+        return TodayPostResponse.builder()
+                .postId(postId)
+                .postStatus(status.name())
+                .build();
+    }
+}

--- a/src/main/java/swyp_11/ssubom/domain/post/repository/PostRepository.java
+++ b/src/main/java/swyp_11/ssubom/domain/post/repository/PostRepository.java
@@ -4,6 +4,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import swyp_11.ssubom.domain.post.entity.Post;
 
+import java.time.LocalDateTime;
+import java.util.Optional;
+
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
+    Optional<Post> findFirstByUser_UserIdAndCreatedAtBetweenOrderByCreatedAtDesc(Long userId, LocalDateTime startOfDay, LocalDateTime endOfDay);
 }

--- a/src/main/java/swyp_11/ssubom/domain/post/service/PostService.java
+++ b/src/main/java/swyp_11/ssubom/domain/post/service/PostService.java
@@ -1,0 +1,30 @@
+package swyp_11.ssubom.domain.post.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import swyp_11.ssubom.domain.post.dto.TodayPostResponse;
+import swyp_11.ssubom.domain.post.entity.PostStatus;
+import swyp_11.ssubom.domain.post.repository.PostRepository;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class PostService {
+    private final PostRepository postRepository;
+
+    public TodayPostResponse findPostStatusByToday(Long userId) {
+        LocalDate today = LocalDate.now();
+        LocalDateTime startOfDay = today.atStartOfDay();
+        LocalDateTime endOfDay = today.atTime(LocalTime.MAX);
+
+        return postRepository
+                .findFirstByUser_UserIdAndCreatedAtBetweenOrderByCreatedAtDesc(userId, startOfDay, endOfDay)
+                .map(post -> TodayPostResponse.toDto(post.getPostId(), post.getStatus()))
+                .orElse(TodayPostResponse.toDto(null, PostStatus.NOT_STARTED));
+    }
+}

--- a/src/main/java/swyp_11/ssubom/domain/topic/controller/CategoryController.java
+++ b/src/main/java/swyp_11/ssubom/domain/topic/controller/CategoryController.java
@@ -4,31 +4,25 @@ package swyp_11.ssubom.domain.topic.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.server.ResponseStatusException;
-import swyp_11.ssubom.domain.topic.dto.TopicCollectionResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import swyp_11.ssubom.domain.topic.dto.HomeResponse;
+import swyp_11.ssubom.domain.topic.dto.TodayTopicResponseDto;
 import swyp_11.ssubom.domain.topic.dto.TopicListResponse;
 import swyp_11.ssubom.domain.topic.service.TopicService;
+import swyp_11.ssubom.domain.user.dto.CustomOAuth2User;
 import swyp_11.ssubom.global.error.BusinessException;
 import swyp_11.ssubom.global.error.ErrorCode;
 import swyp_11.ssubom.global.response.ApiResponse;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RestController;
-import swyp_11.ssubom.domain.topic.dto.TodayTopicResponseDto;
-
-import java.util.List;
 
 
 @Tag(name = "Topic", description = "category , topic 관련 API")
 @RestController
+@RequestMapping("/api")
 @RequiredArgsConstructor
 public class CategoryController {
     private final TopicService topicService;
@@ -42,7 +36,7 @@ public class CategoryController {
             }
     )
 
-    @GetMapping("/api/categories/{categoryId}/question")
+    @GetMapping("/categories/{categoryId}/question")
     public ApiResponse<TodayTopicResponseDto> getCategoryQuestion(@PathVariable("categoryId") Long categoryId) {
         TodayTopicResponseDto dto =topicService.ensureTodayPickedDto(categoryId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.TOPIC_NOT_FOUND));
@@ -58,10 +52,34 @@ public class CategoryController {
                     @Parameter(name = "sort", in = ParameterIn.QUERY, required = false, description = "정렬 기준 (latest | popular)", example = "latest")
             }
     )
-    @GetMapping("/api/categories/{categoryId}/questions")
+    @GetMapping("/categories/{categoryId}/questions")
     public ApiResponse<TopicListResponse> getTopicCollection(@PathVariable("categoryId") Long categoryId, @RequestParam(name = "sort",defaultValue = "latest") String sort) {
         TopicListResponse dto = topicService.getAll(categoryId, sort);
             return ApiResponse.success(dto,"T0003","주제 조회 성공");
     }
 
+    @Operation(
+            summary = "홈 화면 조회",
+            description = """
+                로그인 여부에 따라 다른 정보를 제공합니다.
+                - **비회원**: 카테고리 목록만 조회
+                - **회원**: 카테고리 + 스트릭 + 오늘의 글 상태 포함
+            """,
+            security = { @SecurityRequirement(name = "bearerAuth") }
+    )
+    @GetMapping("/home")
+    public ResponseEntity<ApiResponse<HomeResponse>> getHome(@AuthenticationPrincipal CustomOAuth2User principal) {
+        HomeResponse homeResponse;
+        if (principal == null) {
+            homeResponse = topicService.getHome(null);
+        } else {
+            homeResponse = topicService.getHome(principal.getUserId());
+        }
+        ApiResponse<HomeResponse> response = ApiResponse.success(
+                homeResponse,
+                "H0001",
+                "홈 화면 조회에 성공했습니다."
+        );
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/swyp_11/ssubom/domain/topic/dto/CategoryResponse.java
+++ b/src/main/java/swyp_11/ssubom/domain/topic/dto/CategoryResponse.java
@@ -1,0 +1,23 @@
+package swyp_11.ssubom.domain.topic.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class CategoryResponse {
+    private Long categoryId;
+    private String categoryName;
+
+    @Builder
+    public CategoryResponse(Long categoryId, String categoryName) {
+        this.categoryId = categoryId;
+        this.categoryName = categoryName;
+    }
+
+    public static CategoryResponse toDto(Long categoryId, String categoryName) {
+        return CategoryResponse.builder()
+                .categoryId(categoryId)
+                .categoryName(categoryName)
+                .build();
+    }
+}

--- a/src/main/java/swyp_11/ssubom/domain/topic/dto/HomeResponse.java
+++ b/src/main/java/swyp_11/ssubom/domain/topic/dto/HomeResponse.java
@@ -1,0 +1,30 @@
+package swyp_11.ssubom.domain.topic.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import swyp_11.ssubom.domain.user.dto.StreakResponse;
+import swyp_11.ssubom.domain.post.dto.TodayPostResponse;
+
+import java.util.List;
+
+@Getter
+public class HomeResponse {
+    private StreakResponse streak;
+    private List<CategoryResponse> categories;
+    private TodayPostResponse todayPost;
+
+    @Builder
+    public HomeResponse(StreakResponse streak, List<CategoryResponse> categories, TodayPostResponse todayPost) {
+        this.streak = streak;
+        this.categories = categories;
+        this.todayPost = todayPost;
+    }
+
+    public static HomeResponse toDto(StreakResponse streakCount, List<CategoryResponse> categories, TodayPostResponse todayPosts) {
+        return HomeResponse.builder()
+                .streak(streakCount)
+                .categories(categories)
+                .todayPost(todayPosts)
+                .build();
+    }
+}

--- a/src/main/java/swyp_11/ssubom/domain/topic/repository/CategoryRepository.java
+++ b/src/main/java/swyp_11/ssubom/domain/topic/repository/CategoryRepository.java
@@ -1,0 +1,9 @@
+package swyp_11.ssubom.domain.topic.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import swyp_11.ssubom.domain.topic.entity.Category;
+
+@Repository
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+}

--- a/src/main/java/swyp_11/ssubom/domain/topic/repository/TopicRepository.java
+++ b/src/main/java/swyp_11/ssubom/domain/topic/repository/TopicRepository.java
@@ -26,5 +26,4 @@ public interface TopicRepository extends JpaRepository<Topic, Long> {
 
     List<Topic> findTop30ByCategoryIdAndUsedAtIsNotNullOrderByUsedAtDesc(Long categoryId);
     List<Topic> findTop30ByCategoryIdAndUsedAtIsNotNullOrderByUsedAtAsc(Long categoryId);
-
 }

--- a/src/main/java/swyp_11/ssubom/domain/user/dto/CustomOAuth2User.java
+++ b/src/main/java/swyp_11/ssubom/domain/user/dto/CustomOAuth2User.java
@@ -42,5 +42,7 @@ public class CustomOAuth2User implements OAuth2User {
         return userDTO.getKakaoId();
     }
 
-
+    public Long getUserId() {
+        return userDTO.getUserId();
+    }
 }

--- a/src/main/java/swyp_11/ssubom/domain/user/dto/StreakResponse.java
+++ b/src/main/java/swyp_11/ssubom/domain/user/dto/StreakResponse.java
@@ -1,0 +1,20 @@
+package swyp_11.ssubom.domain.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class StreakResponse {
+    private Long current;
+
+    @Builder
+    public StreakResponse(Long current) {
+        this.current = current;
+    }
+
+    public static StreakResponse toDto(Long streakCount) {
+        return StreakResponse.builder()
+                .current(streakCount)
+                .build();
+    }
+}

--- a/src/main/java/swyp_11/ssubom/domain/user/dto/userDTO.java
+++ b/src/main/java/swyp_11/ssubom/domain/user/dto/userDTO.java
@@ -7,5 +7,5 @@ public class userDTO {
     private String userName;
     private String role;
     private String kakaoId;
-
+    private Long userId;
 }

--- a/src/main/java/swyp_11/ssubom/domain/user/repository/StreakRepository.java
+++ b/src/main/java/swyp_11/ssubom/domain/user/repository/StreakRepository.java
@@ -1,0 +1,12 @@
+package swyp_11.ssubom.domain.user.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import swyp_11.ssubom.domain.user.entity.Streak;
+
+import java.util.Optional;
+
+@Repository
+public interface StreakRepository extends JpaRepository<Streak, Long> {
+    Optional<Streak> findByUser_UserId(Long userId);
+}

--- a/src/main/java/swyp_11/ssubom/domain/user/service/UserService.java
+++ b/src/main/java/swyp_11/ssubom/domain/user/service/UserService.java
@@ -1,0 +1,20 @@
+package swyp_11.ssubom.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import swyp_11.ssubom.domain.user.dto.StreakResponse;
+import swyp_11.ssubom.domain.user.repository.StreakRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserService {
+    private final StreakRepository streakRepository;
+
+    public StreakResponse getStreak(Long userId) {
+        return streakRepository.findByUser_UserId(userId)
+                .map(streak -> StreakResponse.toDto(streak.getStreakCount()))
+                .orElseGet(() -> StreakResponse.toDto(0L));
+    }
+}

--- a/src/main/java/swyp_11/ssubom/global/config/SwaggerConfig.java
+++ b/src/main/java/swyp_11/ssubom/global/config/SwaggerConfig.java
@@ -32,7 +32,5 @@ public class SwaggerConfig {
                         .type(SecurityScheme.Type.HTTP)
                         .scheme("bearer")
                         .bearerFormat("JWT")));
-
-
     }
 }


### PR DESCRIPTION
<!-- 
📝 PR 제목 형식:
<type>: <subject>

예시:
- feat(auth): 세션 기반 로그인 기능 추가

Type:
- feat: 새로운 기능 추가
- fix: 버그 수정
- docs: 문서 관련 수정 (README 등)
- test: 테스트 코드 추가/수정
- refactor: 코드 리팩토링 (기능 변화 없음)
- style: 포맷팅, 세미콜론, 들여쓰기 등 의미 없는 변경
- chore: 빌드, 의존성, 패키지 관리 등
- infra: 배포/서버 환경 구성 변경
-->

## 📌 작업 개요
- 홈 화면 조회 API 개발 완료했습니다.

## 🧩 변경 사항
- 비회원/회원 모두 홈 화면 api 에 접근 가능하므로 
  - 비회원의 경우 streak,  todayPost는 null로 응답하도록 했습니다.
  - 비회원/회원 모두 카테고리를 응답 받을 수 있습니다.
- categoryController 의 RequestMapping("/api") 설정했습니다.
  - 중복으로 입력해야 하는 부분이라 자동으로 붙여지도록 설정했습니다.

## ⚠️ 이슈
- Riido: https://app.riido.io/BAue1RkFcV487AsA2m7wW/teams/2W/tasks/paDR3k11ZeFOv1szbYE49

## 🧠 리뷰어 참고 사항
- 로컬에서 토큰을 발급할 수 없어 임의로 User 데이터를 생성해 테스트했습니다. 배포 환경에서 자세히 테스트 해야 할 것 같습니다.
- http://localhost:8080/swagger-ui/index.html swagger에서 현재 비회원 홈 화면 조회 테스트 가능합니다.
